### PR TITLE
Fixed cookie consent script url

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -21,7 +21,7 @@ class Plugin extends \System\Classes\PluginBase
         // Settings
         Block::append('scripts', '<script type="text/javascript">window.cookieconsent_options = '.json_encode($this->getSettings(), false).';</script>');
         // Consent Cookie
-        Block::append('scripts', '<script src="//s3.amazonaws.com/cc.silktide.com/cookieconsent.'.Settings::get('version', 'latest').'.min.js" type="text/javascript"></script>');
+        Block::append('scripts', '<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/'.Settings::get('version', '1.0.10').'/cookieconsent.min.js" type="text/javascript"></script>');
     }
 
     public function registerSettings()


### PR DESCRIPTION
Since the old S3 URL is no longer available as of 23 November 2015, I updated to the new URL.

See: https://silktide.com/really-important-update-to-users-of-cookie-consent-2/
