### PR TITLE
Added ACL support for SettingsModel

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -25,6 +25,13 @@ class Plugin extends \System\Classes\PluginBase
         Block::append('scripts', '<script type="text/javascript">window.cookieconsent.initialise('.json_encode($this->getSettings(), false).');</script>');
     }
 
+    public function registerPermissions()
+    {
+        return [
+            'nsrosenqvist.cookieconsent.settings' => ['label' => 'Manage CookieConsent Settings', 'tab' => 'CookieConsent']
+        ];
+    }
+
     public function registerSettings()
     {
         return [
@@ -33,7 +40,8 @@ class Plugin extends \System\Classes\PluginBase
                 'description' => 'Manage cookie notification settings.',
                 'icon'        => 'icon-globe',
                 'class'       => 'NSRosenqvist\CookieConsent\Models\Settings',
-                'keywords'    => 'cookie eu law cookies biscuits'
+                'keywords'    => 'cookie eu law cookies biscuits',
+                'permissions' => ['nsrosenqvist.cookieconsent.settings'],
             ]
         ];
     }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -4,3 +4,5 @@
     - Upgraded plugin to work with the service changes
 1.0.2:
     - Upgraded plugin to work with cookieconsent version 3.0.3
+1.0.3
+    - ACL for settings model


### PR DESCRIPTION
I stumbled accross this issue, when I needed to give external parties access to just the _contents_.

This plugin was still completely configurable for any backend-user.

Probably it's a good Idea to make configuration / settings optional.